### PR TITLE
Added Catches to prevent Crashing while clearGuild

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@outwalk/discord-backup",
-  "version": "0.2.1",
+  "version": "0.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@outwalk/discord-backup",
-      "version": "0.2.1",
+      "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",

--- a/src/utils.js
+++ b/src/utils.js
@@ -260,16 +260,16 @@ export async function loadChannel(channelData, guild, category, options, limiter
 /* delete all roles, channels, emojis, etc of a guild */
 export async function clearGuild(guild, limiter) {
     const roles = guild.roles.cache.filter((role) => !role.managed && role.editable && role.id != guild.id);
-    roles.forEach(async (role) => await limiter.schedule(() => role.delete()));
+    roles.forEach(async (role) => await limiter.schedule(() => role.delete().catch((e) => {})));
 
-    guild.channels.cache.forEach(async (channel) => await limiter.schedule(() => channel.delete()));
-    guild.emojis.cache.forEach(async (emoji) => await limiter.schedule(() => emoji.delete()));
+    guild.channels.cache.forEach(async (channel) => await limiter.schedule(() => channel.delete().catch((e) => {})));
+    guild.emojis.cache.forEach(async (emoji) => await limiter.schedule(() => emoji.delete().catch((e) => {})));
 
     const webhooks = await limiter.schedule(() => guild.fetchWebhooks());
-    webhooks.forEach(async (webhook) => await limiter.schedule(() => webhook.delete()));
+    webhooks.forEach(async (webhook) => await limiter.schedule(() => webhook.delete().catch((e) => {})));
 
     const bans = await limiter.schedule(() => guild.bans.fetch());
-    bans.forEach(async (ban) => await limiter.schedule(() => guild.members.unban(ban.user)));
+    bans.forEach(async (ban) => await limiter.schedule(() => guild.members.unban(ban.user).catch((e) => {})));
 
     await limiter.schedule(() => guild.setAFKChannel(null));
     await limiter.schedule(() => guild.setAFKTimeout(60 * 5));


### PR DESCRIPTION
with clearGuild it can happen that channels are not deleted, because they are community related. This problem I prevent with .catch at the respective places