### PR TITLE
Fixed: max bitrate still using v13 format

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -5,15 +5,16 @@ import {
     GuildExplicitContentFilter,
     GuildVerificationLevel,
     GuildSystemChannelFlags,
-    OverwriteType
+    OverwriteType,
+    GuildPremiumTier
 } from "discord.js";
 import axios from "axios";
 
 const MAX_BITRATE_PER_TIER = {
-    NONE: 64000,
-    TIER_1: 128000,
-    TIER_2: 256000,
-    TIER_3: 384000
+    [GuildPremiumTier.None]: 64000,
+    [GuildPremiumTier.Tier1]: 128000,
+    [GuildPremiumTier.Tier2]: 256000,
+    [GuildPremiumTier.Tier3]: 384000
 };
 
 /* gets the permissions for a channel */
@@ -215,7 +216,7 @@ export async function loadChannel(channelData, guild, category, options, limiter
         const bitrates = Object.values(MAX_BITRATE_PER_TIER);
 
         while (bitrate > MAX_BITRATE_PER_TIER[guild.premiumTier]) {
-            bitrate = bitrates[Object.keys(MAX_BITRATE_PER_TIER).indexOf(guild.premiumTier) - 1];
+            bitrate = bitrates[guild.premiumTier];
         }
 
         createOptions.bitrate = bitrate;


### PR DESCRIPTION
This PR fixes a backup load failure caused by `MAX_BITRATE_PER_TIER` using an outdated format. Find more in #7.

This fixes #7.   

Small note for line 219: As GuildPremiumTier is now a number (see [discord-api-types](https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildPremiumTier)), the logic was simplified - please let me know if that is an unwanted change ^^