### PR TITLE
Add missing await to fetchStageChannelData call

### DIFF
--- a/src/functions/create.js
+++ b/src/functions/create.js
@@ -93,7 +93,7 @@ export async function getChannels(guild, options, limiter) {
             } else if (child.type == ChannelType.GuildVoice) {
                 channelData = fetchVoiceChannelData(child);
             } else if (child.type == ChannelType.GuildStageVoice) {
-                channelData = fetchStageChannelData(child, options, limiter);
+                channelData = await fetchStageChannelData(child, options, limiter);
             } else {
                 console.warn(`Unsupported channel type: ${child.type}`);
             }


### PR DESCRIPTION
A missing `await` keyword was removed from the `fetchStageChannelData` function call. This was causing the function to return a Promise instead of the expected data. This change ensures that the `channelData` variable is properly assigned with the output of the function before proceeding.