### PR TITLE
Remove clear guild enforcement before backupLoad without user consent.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,8 @@ async function load(backup, guild, options) {
 
     // Main part of the backup restoration:
     if (!options || !(options.doNotLoad || []).includes("main")) {
-        if (options.clearGuildBeforeRestore == undefined || options.clearGuildBeforeRestore) {
+        // Clear guild only under user consent
+        if (options && options.clearGuildBeforeRestore == true) {
             await clearGuild(guild, limiter);
         }
 


### PR DESCRIPTION
This is has no damage in compare to clearing guild without user put in any interaction, so clearGuild would happened only under user consent.