### PR TITLE
feat(backup): add granular control with toBackup and toLoad options and more bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ await backup.create(guild, {
     maxMessagesPerChannel: 10,
     jsonSave: false,
     jsonBeautify: true,
-    doNotBackup: ["roles", "channels", "emojis", "bans"],
+    doNotBackup: ["bans", "roles", "emojis", "channels"],
+    // toBackup: ["channels"]
     backupMembers: false,
     saveImages: "base64",
     speed: 250,
@@ -113,16 +114,22 @@ await backup.create(guild, {
 **maxMessagesPerChannel**: Maximum of messages to save in each channel. "0" won't save any messages.</br>
 **jsonSave**: Whether to save the backup into a json file. You will have to save the backup data in your own db to load it later.  
 **jsonBeautify**: Whether you want your json backup pretty formatted.</br>
-**doNotBackup**: Items you want to exclude from the backup. Available options are `bans`, `roles`, `emojis`, and `channels`. You can specify all channels or a subset:
+**doNotBackup**: Items you want to exclude from the backup. Available options are `bans`, `roles`, `emojis`, and `channels`. You can specify all channels, a subset of channels, or even a category to exclude all channels under that category:
   - **Exclude specific channels**:
     ```js
     doNotBackup: [{ channels: ["channel_id_1", "channel_id_2"] }]
+    ```
+  - **Exclude an entire category and its child channels**:
+    ```js
+    doNotBackup: [{ channels: ["category_id_1"] }]
     ```
   - **Exclude all channels**:
     ```js
     doNotBackup: ["channels"]
     ```
-**toBackup**: Items you want to include in the backup. Available options are `bans`, `roles`, `emojis`, and `channels`. You can specify all channels or a subset:
+  - **Note**: You cannot use `doNotBackup` at the same time as `toBackup.` You must choose one or the other.
+
+**toBackup**: Items you want to include in the backup. Available options are `bans`, `roles`, `emojis`, and `channels`. You can specify all channels, a subset of channels, or even a category to include all channels under that category:
   - **Include specific channels**:
     ```js
     toBackup: [
@@ -131,10 +138,16 @@ await backup.create(guild, {
         }
     ]
     ```
+  - **Include an entire category and its child channels**:
+    ```js
+    toBackup: [{ channels: ["category_id_2"] }]
+    ```
   - **Include all channels**:
     ```js
     toBackup: ["channels"]
     ```
+  - **Note**: You cannot use `toBackup` at the same time as `doNotBackup`. You must choose one or the other.
+
 **backupMembers**: Wether or not to save information on the members of the server.</br>
 **saveImages**: How to save images like guild icon and emojis. Set to "url" by default, restoration may not work if the old server is deleted. So, `url` is recommended if you want to clone a server (or if you need very light backups), and `base64` if you want to backup a server. Save images as base64 creates heavier backups.</br>
 **speed**: What speed to run at, default is 250 (measured in ms)</br>
@@ -193,6 +206,7 @@ await backup.load(backupData, guild, {
     maxMessagesPerChannel: 10,
     speed: 250,
     doNotLoad: ["roleAssignments", "emojis"],
+    // toLoad: ["channels"],
     onStatusChange: (status) => {
         console.log(
           `[Restoring] Step: ${status.step} | Progress: ${
@@ -206,7 +220,40 @@ await backup.load(backupData, guild, {
 **maxMessagesPerChannel**: Maximum of messages to restore in each channel. "0" won't restore any messages.</br>
 **speed**: What speed to run at, default is 250 (measured in ms)</br>
 **verbose**: Determines if the output should be verbose or not.</br>
-**doNotLoad**: Things you dont want to restore. Available items are: `main`, `roleAssignments`, `emojis`, `roles`, & `channels`. `main` will prevent loading the main backup, `roleAssignments` will prevent reassigning roles to members, `emojis` will prevent restoring emojis, `roles` will prevent restoring roles and `channels` will prevent restoring channels.</br>
+**doNotLoad**: Items you don't want to restore. Available options are `main`, `roleAssignments`, `emojis`, `roles`, and `channels`. You can specify all channels, a subset of channels, or even a category to exclude all channels under that category:
+  - **Exclude specific channels**:
+    ```js
+    doNotLoad: [{ channels: ["channel_id_1", "channel_id_2"] }]
+    ```
+  - **Exclude an entire category and its child channels**:
+    ```js
+    doNotLoad: [{ channels: ["category_id_1"] }]
+    ```
+  - **Exclude all channels**:
+    ```js
+    doNotLoad: ["channels"]
+    ```
+  - **Note**: You cannot use `doNotLoad` at the same time as `toLoad`. You must choose one or the other.
+
+**toLoad**: Items you want to restore. Available options are `main`, `roleAssignments`, `emojis`, `roles`, and `channels`. You can specify all channels, a subset of channels, or even a category to include all channels under that category:
+  - **Include specific channels**:
+    ```js
+    toLoad: [
+        {
+            channels: ["channel_id_3", "channel_id_4"]
+        }
+    ]
+    ```
+  - **Include an entire category and its child channels**:
+    ```js
+    toLoad: [{ channels: ["category_id_2"] }]
+    ```
+  - **Include all channels**:
+    ```js
+    toLoad: ["channels"]
+    ```
+  - **Note**: You cannot use `toLoad` at the same time as `doNotLoad`. You must choose one or the other.
+
 **onStatusChange**: A callback function to handle the status updates during the restoration process. Similar to backup, it provides the `step`, `progress`, `percentage`, and `info`.</br>
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install @outwalk/discord-backup
 
 ### Create
 
-Create a backup for the specified server.
+Create a backup for the specified server. **You don't need to provide `toBackup` or `doNotBackup` options**—the module will back up all data by default if these options are not specified.
 
 ```js
 import backup from "@outwalk/discord-backup";
@@ -32,7 +32,7 @@ const backupData = await backup.create(guild, options);
 
 ### Load
 
-Allows you to load a backup on a Discord server!
+Allows you to load a backup on a Discord server! **You don't need to provide toLoad or doNotLoad options**—the module will load all data by default if these options are not specified.
 
 ```js
 import backup from "@outwalk/discord-backup";
@@ -109,6 +109,7 @@ await backup.create(guild, {
     }
 });
 ```
+Note: If `toBackup` or `doNotBackup` are not provided, the module will back up all data by default.</br>
 
 **backupId**: Specify an Id to be used for the backup, if not provided a random one will be generated.</br>
 **maxMessagesPerChannel**: Maximum of messages to save in each channel. "0" won't save any messages.</br>
@@ -215,6 +216,7 @@ await backup.load(backupData, guild, {
         );
 });
 ```
+Note: If `toLoad` or `doNotLoad` are not provided, the module will load all data by default.</br>
 
 **clearGuildBeforeRestore**: Whether to clear the guild (roles, channels, etc... will be deleted) before the backup restoration (recommended).</br>
 **maxMessagesPerChannel**: Maximum of messages to restore in each channel. "0" won't restore any messages.</br>

--- a/README.md
+++ b/README.md
@@ -113,19 +113,28 @@ await backup.create(guild, {
 **maxMessagesPerChannel**: Maximum of messages to save in each channel. "0" won't save any messages.</br>
 **jsonSave**: Whether to save the backup into a json file. You will have to save the backup data in your own db to load it later.  
 **jsonBeautify**: Whether you want your json backup pretty formatted.</br>
-**doNotBackup**: Things you don't want to backup. The `doNotBackup` option can exclude specific channels. Available items are: `roles`, `channels`, `emojis`, `bans`.</br>
+**doNotBackup**: Items you want to exclude from the backup. Available options are `bans`, `roles`, `emojis`, and `channels`. You can specify all channels or a subset:
   - **Exclude specific channels**:
     ```js
-    doNotBackup: ["roles", { channels: ["channel_id_1", "channel_id_2"] }, "emojis", "bans"]
-    ```
-  - **Exclude a single channel**:
-    ```js
-    doNotBackup: ["roles", { channels: ["channel_id_1"] }, "emojis", "bans"]
+    doNotBackup: [{ channels: ["channel_id_1", "channel_id_2"] }]
     ```
   - **Exclude all channels**:
     ```js
-    doNotBackup: ["roles", "channels", "emojis", "bans"]
-    ```  
+    doNotBackup: ["channels"]
+    ```
+**toBackup**: Items you want to include in the backup. Available options are `bans`, `roles`, `emojis`, and `channels`. You can specify all channels or a subset:
+  - **Include specific channels**:
+    ```js
+    toBackup: [
+        {
+            channels: ["channel_id_3", "channel_id_4"]
+        }
+    ]
+    ```
+  - **Include all channels**:
+    ```js
+    toBackup: ["channels"]
+    ```
 **backupMembers**: Wether or not to save information on the members of the server.</br>
 **saveImages**: How to save images like guild icon and emojis. Set to "url" by default, restoration may not work if the old server is deleted. So, `url` is recommended if you want to clone a server (or if you need very light backups), and `base64` if you want to backup a server. Save images as base64 creates heavier backups.</br>
 **speed**: What speed to run at, default is 250 (measured in ms)</br>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outwalk/discord-backup",
   "type": "module",
-  "version": "0.7.8",
+  "version": "0.8.0",
   "publishConfig": {
     "access": "public"
   },

--- a/src/functions/create.js
+++ b/src/functions/create.js
@@ -8,36 +8,65 @@ import {
     logStatus
 } from "../utils";
 
-/* Helper function to check if a channel should be excluded or included */
-function shouldExcludeChannel(channel, doNotBackup, toBackup) {
-    // If "channels" is included in `toBackup`, include all channels.
-    if (toBackup && toBackup.some(item => item === "channels")) {
-        return false;
+/* Helper function to check if a channel should be excluded */
+function shouldExcludeChannel(channel, doNotBackupList) {
+    const channelId = channel.id;
+
+    // If the channel is explicitly listed in the `doNotBackupList`, exclude it.
+    if (doNotBackupList.includes(channelId)) {
+        console.log(`[DEBUG] Channel/Category ${channel.name} (${channelId}) is explicitly excluded by doNotBackup list.`);
+        return true;
     }
 
-    // If specific channels are mentioned in `toBackup`, exclude those not listed.
-    if (toBackup && toBackup.length > 0) {
-        const toBackupList = toBackup.flatMap(item => item.channels || []);
-        // For categories, include if any child is in the `toBackup` list.
-        if (channel.type === ChannelType.GuildCategory) {
-            const childChannels = channel.children.cache.map(child => child.id);
-            const isChildInBackup = childChannels.some(childId => toBackupList.includes(childId));
-            return !isChildInBackup;
+    // If the channel is a category, exclude it if the category itself is listed or all of its children are listed.
+    if (channel.type === ChannelType.GuildCategory && channel.children) {
+        const childChannels = channel.children.cache.map(child => child.id);
+
+        // Exclude the entire category if its ID is in the `doNotBackupList`.
+        if (doNotBackupList.includes(channelId)) {
+            console.log(`[DEBUG] Excluding entire Category ${channel.name} (${channelId}) as it's in the doNotBackup list.`);
+            return true;
         }
-        // For other channels, exclude if not in the `toBackup` list.
-        return !toBackupList.includes(channel.id);
+
+        // Exclude the category if all of its children are listed in the `doNotBackupList`.
+        const isChildInDoNotBackup = childChannels.every(childId => doNotBackupList.includes(childId));
+        if (isChildInDoNotBackup) {
+            console.log(`[DEBUG] Excluding Category ${channel.name} (${channelId}) because all of its children are in the doNotBackup list.`);
+            return true;
+        }
     }
 
-    // Handle `doNotBackup` as a fallback.
-    if (doNotBackup && doNotBackup.length > 0) {
-        const doNotBackupList = doNotBackup.flatMap(item => item.channels || []);
-        return doNotBackupList.includes(channel.id);
-    }
-
-    // By default, do not exclude any channels.
-    return false;
+    return false; // By default, do not exclude any channel.
 }
 
+/* Helper function to check if a channel should be included */
+function shouldIncludeChannel(channel, toBackupList) {
+    const channelId = channel.id;
+
+    // Include if the channel or category is explicitly in the `toBackup` list.
+    if (toBackupList.includes(channelId)) {
+        console.log(`[DEBUG] Channel/Category ${channel.name} (${channelId}) is explicitly included in toBackup list.`);
+        return true;
+    }
+
+    // If the channel is a category, include it if any of its children are explicitly listed.
+    if (channel.type === ChannelType.GuildCategory && channel.children) {
+        const childChannels = channel.children.cache.map(child => child.id);
+        const isChildInToBackup = childChannels.some(childId => toBackupList.includes(childId));
+        if (isChildInToBackup) {
+            console.log(`[DEBUG] Including Category ${channel.name} (${channelId}) because one of its children is in the toBackup list.`);
+            return true;
+        }
+    }
+
+    // For individual channels, include their parent category if they are explicitly listed.
+    if (channel.parent && toBackupList.includes(channelId)) {
+        console.log(`[DEBUG] Including parent category ${channel.parent.name} (${channel.parent.id}) for the channel ${channel.name} (${channelId}).`);
+        return true;
+    }
+
+    return false; // By default, do not include any channel.
+}
 
 /* returns an array with the banned members of the guild */
 export async function getBans(guild, limiter, options) {
@@ -152,15 +181,13 @@ export async function getEmojis(guild, limiter, options) {
     return collectedEmojis;
 }
 
+
 /* returns an array with the channels of the guild */
 export async function getChannels(guild, limiter, options) {
     const channels = await limiter.schedule({ id: "getChannels::guild.channels.fetch" }, () => guild.channels.fetch());
     const collectedChannels = { categories: [], others: [] };
     let totalChannels = 0;
     let savedChannels = 0;
-
-    const doNotBackup = options.doNotBackup || [];
-    const toBackup = options.toBackup || [];
 
     const categories = channels
         .filter((channel) => channel.type == ChannelType.GuildCategory)
@@ -169,28 +196,19 @@ export async function getChannels(guild, limiter, options) {
 
     // Calculate the total number of channels to be processed
     totalChannels = channels.filter(
-        (channel) => {
-            const exclude = shouldExcludeChannel(channel, doNotBackup, toBackup);
-            return channel.type !== ChannelType.GuildCategory && !exclude;
-        }
+        (channel) => channel.type !== ChannelType.GuildCategory
     ).size;
 
-    // Process categories and their children
     for (let category of categories) {
-        if (shouldExcludeChannel(category, doNotBackup, toBackup)) continue;
-
         const categoryData = { name: category.name, permissions: fetchChannelPermissions(category), children: [] };
 
-        const children = category.children.cache
-            .filter((child) => !shouldExcludeChannel(child, doNotBackup, toBackup))
-            .sort((a, b) => a.position - b.position)
-            .toJSON();
+        const children = category.children.cache.sort((a, b) => a.position - b.position).toJSON();
 
         for (let child of children) {
             let channelData;
-            const info = `Backed up Channel: ${child.name} (Category: ${category.name})`;
+            const info = `Backed up Channel: ${child.name} (Category: ${category.name})`
 
-            if (child.type === ChannelType.GuildText || child.type == ChannelType.GuildAnnouncement) {
+            if (child.type == ChannelType.GuildText || child.type == ChannelType.GuildAnnouncement) {
                 channelData = await fetchTextChannelData(child, options, limiter);
             } else if (child.type == ChannelType.GuildVoice) {
                 channelData = fetchVoiceChannelData(child);
@@ -211,17 +229,14 @@ export async function getChannels(guild, limiter, options) {
         collectedChannels.categories.push(categoryData);
     }
 
-    // Process non-categorized channels
     const others = channels
         .filter((channel) => {
-            const exclude = shouldExcludeChannel(channel, doNotBackup, toBackup);
             return (
                 !channel.parent &&
                 channel.type != ChannelType.GuildCategory &&
                 channel.type != ChannelType.AnnouncementThread &&
                 channel.type != ChannelType.PrivateThread &&
-                channel.type != ChannelType.PublicThread &&
-                !exclude
+                channel.type != ChannelType.PublicThread
             );
         })
         .sort((a, b) => a.position - b.position)
@@ -229,11 +244,263 @@ export async function getChannels(guild, limiter, options) {
 
     for (let channel of others) {
         let channelData;
+        const info = `Backed up Channel: ${channel.name}`
+
+        if (channel.type == ChannelType.GuildText || channel.type == ChannelType.GuildAnnouncement) {
+            channelData = await fetchTextChannelData(channel, options, limiter);
+        } else {
+            channelData = fetchVoiceChannelData(channel);
+        }
+        if (channelData) {
+            channelData.oldId = channel.id;
+            collectedChannels.others.push(channelData);
+            savedChannels++;
+            await logStatus("Channels", savedChannels, totalChannels, options, info);
+        }
+    }
+
+    return collectedChannels;
+}
+
+/* Helper function to fetch channels and exclude them based on doNotBackup */
+export async function doNotBackupgetChannels(guild, limiter, options) {
+    const channels = await limiter.schedule({ id: "getChannels::guild.channels.fetch" }, () => guild.channels.fetch());
+    const collectedChannels = { categories: [], others: [] };
+    let savedChannels = 0;
+
+    const doNotBackup = options.doNotBackup || [];
+    const doNotBackupList = doNotBackup.flatMap(item => item.channels || []);
+
+    const categories = channels
+        .filter((channel) => channel.type === ChannelType.GuildCategory)
+        .sort((a, b) => a.position - b.position)
+        .toJSON();
+
+    console.log(`[DEBUG] Starting process to exclude channels. Total categories: ${categories.length}.`);
+
+    // Calculate the total number of channels to be backed up before the backup starts
+    let totalChannels = 0;
+
+    // Process categories and their children first
+    for (let category of categories) {
+        if (shouldExcludeChannel(category, doNotBackupList)) {
+            console.log(`[DEBUG] Skipping Category: ${category.name} (${category.id}) as it is excluded.`);
+            continue;
+        }
+
+        const nonExcludedChildren = category.children.cache
+            .filter((child) => !shouldExcludeChannel(child, doNotBackupList))
+            .sort((a, b) => a.position - b.position)
+            .toJSON();
+
+        // Only count the category if it has non-excluded children
+        if (nonExcludedChildren.length > 0) {
+            totalChannels += nonExcludedChildren.length;
+        } else {
+            console.log(`[DEBUG] Skipping Category: ${category.name} as all its children are excluded.`);
+        }
+    }
+
+    // Process non-categorized channels
+    const others = channels
+        .filter((channel) => {
+            const exclude = shouldExcludeChannel(channel, doNotBackupList);
+            return (
+                !channel.parent &&
+                channel.type !== ChannelType.GuildCategory &&
+                !exclude
+            );
+        })
+        .sort((a, b) => a.position - b.position)
+        .toJSON();
+
+    totalChannels += others.length;
+
+    console.log(`[DEBUG] Total channels to be backed up: ${totalChannels}.`);
+
+    // Backup logic for categories
+    for (let category of categories) {
+        if (shouldExcludeChannel(category, doNotBackupList)) continue;
+
+        const nonExcludedChildren = category.children.cache
+            .filter((child) => !shouldExcludeChannel(child, doNotBackupList))
+            .sort((a, b) => a.position - b.position)
+            .toJSON();
+
+        if (nonExcludedChildren.length === 0) continue;
+
+        const categoryData = {
+            name: category.name,
+            permissions: fetchChannelPermissions(category),
+            children: []
+        };
+
+        for (let child of nonExcludedChildren) {
+            let channelData;
+            const info = `Backed up Channel: ${child.name} (Category: ${category.name})`;
+
+            if (child.type === ChannelType.GuildText || child.type === ChannelType.GuildAnnouncement) {
+                channelData = await fetchTextChannelData(child, options, limiter);
+            } else if (child.type === ChannelType.GuildVoice) {
+                channelData = fetchVoiceChannelData(child);
+            } else if (child.type === ChannelType.GuildStageVoice) {
+                channelData = await fetchStageChannelData(child, options, limiter);
+            } else {
+                console.warn(`[DEBUG] Unsupported channel type: ${child.type} for channel ${child.name}.`);
+            }
+
+            if (channelData) {
+                channelData.oldId = child.id;
+                categoryData.children.push(channelData);
+                savedChannels++;  // Increment only when a channel is backed up
+                await logStatus("Channels", savedChannels, totalChannels, options, info);
+                console.log(`[DEBUG] Backed up Channel: ${child.name} (${child.id}) in Category: ${category.name}.`);
+            }
+        }
+
+        // Add category to the list if it has any non-excluded children.
+        if (categoryData.children.length > 0) {
+            collectedChannels.categories.push(categoryData);
+        }
+    }
+
+    // Backup logic for non-categorized channels
+    for (let channel of others) {
+        let channelData;
         const info = `Backed up Channel: ${channel.name}`;
 
-        if (channel.type === ChannelType.GuildText || channel.type == ChannelType.GuildAnnouncement) {
+        if (channel.type === ChannelType.GuildText || channel.type === ChannelType.GuildAnnouncement) {
             channelData = await fetchTextChannelData(channel, options, limiter);
-        } else if (channel.type == ChannelType.GuildVoice) {
+        } else if (channel.type === ChannelType.GuildVoice) {
+            channelData = fetchVoiceChannelData(channel);
+        }
+
+        if (channelData) {
+            channelData.oldId = channel.id;
+            collectedChannels.others.push(channelData);
+            savedChannels++;  // Increment only when a channel is backed up
+            await logStatus("Channels", savedChannels, totalChannels, options, info);
+            console.log(`[DEBUG] Backed up Non-Categorized Channel: ${channel.name} (${channel.id}).`);
+        }
+    }
+
+    console.log(`[DEBUG] Finished backing up channels. Total saved: ${savedChannels}/${totalChannels}.`);
+
+    return collectedChannels;
+}
+
+/* returns an array with the channels of the guild */
+export async function toBackupgetChannels(guild, limiter, options) {
+    const channels = await limiter.schedule({ id: "getChannels::guild.channels.fetch" }, () => guild.channels.fetch());
+    const collectedChannels = { categories: [], others: [] };
+    let totalChannels = 0;
+    let savedChannels = 0;
+
+    const toBackup = options.toBackup || [];
+    const toBackupList = toBackup.flatMap(item => item.channels || []);
+
+    const categories = channels
+        .filter((channel) => channel.type === ChannelType.GuildCategory)
+        .sort((a, b) => a.position - b.position)
+        .toJSON();
+
+    console.log(`[DEBUG] Starting backup process for channels. Total categories: ${categories.length}.`);
+
+    // Calculate total channels before backup starts
+    for (let category of categories) {
+        const includeCategory = shouldIncludeChannel(category, toBackupList);
+
+        if (!includeCategory) {
+            console.log(`[DEBUG] Skipping Category: ${category.name} (${category.id}) as it is not in the toBackup list.`);
+            continue;
+        }
+
+        // Count only child channels that are explicitly listed or if the entire category is included.
+        const includedChildren = category.children.cache
+            .filter((child) => shouldIncludeChannel(child, toBackupList) || toBackupList.includes(category.id))
+            .toJSON();
+
+        totalChannels += includedChildren.length;
+    }
+
+    // Calculate the number of non-categorized channels to be backed up
+    const nonCategorizedChannels = channels
+        .filter((channel) => {
+            const include = shouldIncludeChannel(channel, toBackupList);
+            return (
+                !channel.parent &&
+                channel.type !== ChannelType.GuildCategory &&
+                include
+            );
+        })
+        .toJSON();
+
+    totalChannels += nonCategorizedChannels.length;
+    console.log(`[DEBUG] Total channels to be backed up: ${totalChannels}.`);
+
+    // Process categories and their children
+    for (let category of categories) {
+        const includeCategory = shouldIncludeChannel(category, toBackupList);
+
+        if (!includeCategory) {
+            console.log(`[DEBUG] Skipping Category: ${category.name} (${category.id}) as it is not in the toBackup list.`);
+            continue;
+        }
+
+        console.log(`[DEBUG] Processing Category: ${category.name} (${category.id}).`);
+
+        // Include only specified child channels or include all if the category itself is listed.
+        const includedChildren = category.children.cache
+            .filter((child) => shouldIncludeChannel(child, toBackupList) || toBackupList.includes(category.id))
+            .sort((a, b) => a.position - b.position)
+            .toJSON();
+
+        console.log(`[DEBUG] Creating Category: ${category.name} with ${includedChildren.length} included children.`);
+
+        const categoryData = {
+            name: category.name,
+            permissions: fetchChannelPermissions(category),
+            children: []
+        };
+
+        for (let child of includedChildren) {
+            let channelData;
+            const info = `Backed up Channel: ${child.name} (Category: ${category.name})`;
+
+            if (child.type === ChannelType.GuildText || child.type === ChannelType.GuildAnnouncement) {
+                channelData = await fetchTextChannelData(child, options, limiter);
+            } else if (child.type === ChannelType.GuildVoice) {
+                channelData = fetchVoiceChannelData(child);
+            } else if (child.type === ChannelType.GuildStageVoice) {
+                channelData = await fetchStageChannelData(child, options, limiter);
+            } else {
+                console.warn(`[DEBUG] Unsupported channel type: ${child.type} for channel ${child.name}.`);
+            }
+
+            if (channelData) {
+                channelData.oldId = child.id;
+                categoryData.children.push(channelData);
+                savedChannels++;
+                await logStatus("Channels", savedChannels, totalChannels, options, info);
+                console.log(`[DEBUG] Backed up Channel: ${child.name} (${child.id}) in Category: ${category.name}.`);
+            }
+        }
+
+        // Only add the category if there are included children.
+        if (categoryData.children.length > 0) {
+            collectedChannels.categories.push(categoryData);
+        }
+    }
+
+    // Process non-categorized channels
+    console.log(`[DEBUG] Processing ${nonCategorizedChannels.length} non-categorized channels.`);
+    for (let channel of nonCategorizedChannels) {
+        let channelData;
+        const info = `Backed up Channel: ${channel.name}`;
+
+        if (channel.type === ChannelType.GuildText || channel.type === ChannelType.GuildAnnouncement) {
+            channelData = await fetchTextChannelData(channel, options, limiter);
+        } else if (channel.type === ChannelType.GuildVoice) {
             channelData = fetchVoiceChannelData(channel);
         }
 
@@ -242,8 +509,11 @@ export async function getChannels(guild, limiter, options) {
             collectedChannels.others.push(channelData);
             savedChannels++;
             await logStatus("Channels", savedChannels, totalChannels, options, info);
+            console.log(`[DEBUG] Backed up Non-Categorized Channel: ${channel.name} (${channel.id}).`);
         }
     }
+
+    console.log(`[DEBUG] Finished backing up channels. Total saved: ${savedChannels}/${totalChannels}.`);
 
     return collectedChannels;
 }
@@ -305,5 +575,7 @@ export default {
     getRoles,
     getEmojis,
     getChannels,
+    doNotBackupgetChannels,
+    toBackupgetChannels,
     getAutoModerationRules,
 };

--- a/src/functions/create.js
+++ b/src/functions/create.js
@@ -100,7 +100,7 @@ export async function getRoles(guild, limiter, options) {
 }
 
 /* returns an array with the emojis of the guild */
-export async function getEmojis(guild, options, limiter) {
+export async function getEmojis(guild, limiter, options) {
 
     const emojis = await limiter.schedule({ id: "getEmojis::guild.emojis.fetch" }, () => guild.emojis.fetch());
     const totalEmojis = emojis.size;
@@ -130,7 +130,7 @@ export async function getEmojis(guild, options, limiter) {
 }
 
 /* returns an array with the channels of the guild */
-export async function getChannels(guild, options, limiter) {
+export async function getChannels(guild, limiter, options) {
 
     const channels = await limiter.schedule({ id: "getChannels::guild.channels.fetch" }, () => guild.channels.fetch());
     const collectedChannels = { categories: [], others: [] };

--- a/src/functions/load.js
+++ b/src/functions/load.js
@@ -127,7 +127,7 @@ export async function loadRoles(guild, backup, limiter, options) {
 }
 
 /* restore the guild channels */
-export async function loadChannels(guild, backup, options, limiter) {
+export async function loadChannels(guild, backup, limiter, options) {
 
     const totalChannels = backup.channels.categories.reduce((acc, category) => acc + category.children.length, 0) + backup.channels.others.length;
     let savedChannels = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -200,14 +200,18 @@ async function create(guild, options = {}) {
             backup.emojis = await createFunctions.getEmojis(guild, limiter, options);
         }
 
-        if (toBackupList && toBackupList.length > 0) {
+        if (toBackupList.includes("channels")) {
             backup.channels = await createFunctions.getChannels(guild, limiter, options);
+        }  
+
+        if (toBackupList && toBackupList.length > 0 && !toBackupList.includes("channels")) {
+            backup.channels = await createFunctions.toBackupgetChannels(guild, limiter, options);
         }
 
         if (options && options.backupMembers) {
             backup.members = await createFunctions.getMembers(guild, limiter, options);
         }
-    } else {
+    } else if (options.doNotBackup.length > 0) {
         // Use doNotBackup to exclude backup of specific items.
         if (!options || !(options.doNotBackup || []).includes("bans")) {
             if (check2FA(options, guild, "bans")) {
@@ -224,7 +228,7 @@ async function create(guild, options = {}) {
         }
 
         if (!options || !(options.doNotBackup || []).includes("channels")) {
-            backup.channels = await createFunctions.getChannels(guild, limiter, options);
+            backup.channels = await createFunctions.doNotBackupgetChannels(guild, limiter, options);
         }
 
         if (options && options.backupMembers) {
@@ -323,7 +327,7 @@ async function load(backup, guild, options) {
         }
 
         if (toLoadList && toLoadList.length > 0) {
-            await loadFunctions.loadChannels(guild, backupData, limiter, options);
+            await loadFunctions.toLoadloadChannels(guild, backupData, limiter, options);
         }
 
         if (toLoadList.includes("main")) {
@@ -342,7 +346,7 @@ async function load(backup, guild, options) {
         if (toLoadList.includes("emojis")) {
             await loadFunctions.loadEmojis(guild, backupData, limiter, options);
         }
-    } else {
+    } else if (options.doNotLoad.length > 0) {
         // Use doNotLoad to exclude load of specific items.
         if (!options || !(options.doNotLoad || []).includes("main")) {
             if (options.clearGuildBeforeRestore == undefined || options.clearGuildBeforeRestore) {
@@ -361,7 +365,7 @@ async function load(backup, guild, options) {
         }
 
         if (!options || !(options.doNotLoad || []).includes("channels")) {
-            await loadFunctions.loadChannels(guild, backupData, limiter, options);
+            await loadFunctions.doNotLoadloadChannels(guild, backupData, limiter, options);
         }
 
         if (!options || !(options.doNotLoad || []).includes("main")) {

--- a/src/index.js
+++ b/src/index.js
@@ -68,12 +68,18 @@ async function create(guild, options = {}) {
     if (!intents.has(GatewayIntentBits.Guilds))
         throw new Error("GUILDS intent is required");
 
+    // Ensure `toBackup` and `doNotBackup` are not used together
+    if (options.toBackup && options.doNotBackup) {
+        throw new Error("You cannot use both 'toBackup' and 'doNotBackup' options at the same time.");
+    }
+
     options = {
         backupId: null,
         maxMessagesPerChannel: 10,
         jsonSave: true,
         jsonBeautify: false,
         doNotBackup: [],
+        toBackup: [],
         backupMembers: false,
         saveImages: true,
         speed: 250,

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,6 +71,7 @@ export function fetchVoiceChannelData(channel) {
 /* fetches the stage channel data that is necessary for the backup */
 export async function fetchStageChannelData(channel, options, limiter) {
     const channelData = {
+        id: channel.id,
         type: ChannelType.GuildStageVoice,
         name: channel.name,
         nsfw: channel.nsfw,
@@ -153,6 +154,7 @@ export async function fetchChannelMessages(channel, options, limiter) {
 /* fetches the text channel data that is necessary for the backup */
 export async function fetchTextChannelData(channel, options, limiter) {
     const channelData = {
+        id: channel.id,
         type: channel.type,
         name: channel.name,
         nsfw: channel.nsfw,
@@ -169,6 +171,7 @@ export async function fetchTextChannelData(channel, options, limiter) {
     if (channel.threads.cache.size > 0) {
         channel.threads.cache.forEach(async (thread) => {
             const threadData = {
+                id: thread.id,
                 type: thread.type,
                 name: thread.name,
                 archived: thread.archived,
@@ -217,50 +220,84 @@ export async function loadCategory(categoryData, guild, limiter) {
 
 /* creates a channel and returns it */
 export async function loadChannel(channelData, guild, category, options, limiter) {
+    const restoredThreads = new Set();
 
+    // Function to load messages into a channel
     const loadMessages = async (channel, messages, previousWebhook) => {
-        const webhook = previousWebhook || await limiter.schedule({ id: `loadMessages::channel.createWebhook::${channel.id}.${channel.name}` }, () => channel.createWebhook({ name: "MessagesBackup", avatar: channel.client.user.displayAvatarURL() }));
+        const webhook = previousWebhook || await limiter.schedule(
+            { id: `loadMessages::channel.createWebhook::${channel.id}.${channel.name}` },
+            () => channel.createWebhook({ name: "MessagesBackup", avatar: channel.client.user.displayAvatarURL() })
+        );
         if (!webhook) return;
 
-        messages = messages.filter((message) => (message.content.length > 0 || message.embeds.length > 0 || message.files.length > 0)).reverse();
+        messages = messages.reverse(); // Process messages in reverse order
 
-        // Limit the amount of messages to send
-        if (options.maxMessagesPerChannel && options.maxMessagesPerChannel < messages.length) {
-            messages = messages.slice(messages.length - options.maxMessagesPerChannel);
-        }
+        // Filter out any messages that are thread names or empty content
+        messages = messages.filter(message => message.content.length > 0 || message.embeds.length > 0 || message.files.length > 0);
 
         for (let message of messages) {
-            if (message.content.length > 2000) continue;
+            if (message.content.length > 2000) continue; // Skip overly long messages
+
             try {
                 let sent;
-                // Check if the message was sent by the client user
-                if (message?.userId == channel.client.user.id) {
-                    sent = await limiter.schedule({ id: `loadMessages::channel.send::${channel.id}.${channel.name}` }, () => channel.send({
-                        content: message.content.length ? message.content : undefined,
-                        embeds: message.embeds,
-                        components: message.components,
-                        files: message.files,
-                        allowedMentions: options.allowedMentions
-                    }));
-                    // Else, send the message as a webhook
-                } else {
-                    sent = await limiter.schedule({ id: `loadMessages::webhook.send::${channel.id}.${channel.name}` }, () => webhook.send({
-                        content: message.content.length ? message.content : undefined,
-                        username: message.username,
-                        avatarURL: message.avatar,
-                        embeds: message.embeds,
-                        components: message?.components, //Send message components with backwards compatibility
-                        files: message.files,
-                        allowedMentions: options.allowedMentions,
-                        threadId: channel.isThread() ? channel.id : undefined
-                    }));
 
+                // Check if the message `oldId` matches any thread `id` in the channel data
+                const matchingThread = channelData.threads.find(thread => thread.id === message.oldId);
+
+                if (matchingThread) {
+                    // Skip sending this message as it represents a thread title
+                    restoredThreads.add(matchingThread.id); // Mark thread as restored
+
+                    // Restore the thread at this moment instead of sending the message
+                    const thread = await limiter.schedule(
+                        { id: `loadChannel::channel.threads.create::${matchingThread.name}` },
+                        () => channel.threads.create({
+                            name: matchingThread.name,
+                            autoArchiveDuration: matchingThread.autoArchiveDuration
+                        })
+                    );
+
+                    // Restore the messages of the thread using the webhook
+                    await loadMessages(thread, matchingThread.messages, webhook);
+
+                } else if (message.userId === channel.client.user.id) {
+                    // If the message was sent by the client user, restore as a normal message
+                    sent = await limiter.schedule(
+                        { id: `loadMessages::channel.send::${channel.id}.${channel.name}` },
+                        () => channel.send({
+                            content: message.content.length ? message.content : undefined,
+                            embeds: message.embeds,
+                            components: message.components,
+                            files: message.files,
+                            allowedMentions: options.allowedMentions
+                        })
+                    );
+                } else {
+                    // Otherwise, send the message using the webhook
+                    sent = await limiter.schedule(
+                        { id: `loadMessages::webhook.send::${channel.id}.${channel.name}` },
+                        () => webhook.send({
+                            content: message.content.length ? message.content : undefined,
+                            username: message.username,
+                            avatarURL: message.avatar,
+                            embeds: message.embeds,
+                            components: message.components,
+                            files: message.files,
+                            allowedMentions: options.allowedMentions,
+                            threadId: channel.isThread() ? channel.id : undefined
+                        })
+                    );
                 }
 
-                if (message.pinned && sent) await limiter.schedule({ id: `loadMessages::sent.pin::${channel.id}.${channel.name}` }, () => sent.pin());
+                // Pin the message if it was originally pinned
+                if (message.pinned && sent) {
+                    await limiter.schedule(
+                        { id: `loadMessages::sent.pin::${channel.id}.${channel.name}` },
+                        () => sent.pin()
+                    );
+                }
             } catch (error) {
-                /* ignore errors where it request entity is too large */
-                if (error.message == "Request entity too large") return;
+                if (error.message === "Request entity too large") return; // Handle large entity errors
                 console.error(error);
             }
         }
@@ -268,52 +305,36 @@ export async function loadChannel(channelData, guild, category, options, limiter
         return webhook;
     };
 
+    // Create the channel object
     const createOptions = { name: channelData.name, type: null, parent: category };
 
+    // Determine the type of the channel
     if (channelData.type == ChannelType.GuildText || channelData.type == ChannelType.GuildAnnouncement) {
         createOptions.topic = channelData.topic;
         createOptions.nsfw = channelData.nsfw;
         createOptions.rateLimitPerUser = channelData.rateLimitPerUser;
-        createOptions.type = channelData.isNews && guild.features.includes(GuildFeature.News) ? ChannelType.GuildAnnouncement : ChannelType.GuildText;
-    }
-
-    else if (channelData.type == ChannelType.GuildVoice) {
-        let bitrate = channelData.bitrate;
-        const bitrates = Object.values(MAX_BITRATE_PER_TIER);
-
-        while (bitrate > MAX_BITRATE_PER_TIER[guild.premiumTier]) {
-            bitrate = bitrates[guild.premiumTier];
-        }
-
-        createOptions.bitrate = bitrate;
+        createOptions.type = channelData.isNews && guild.features.includes("NEWS") ? ChannelType.GuildAnnouncement : ChannelType.GuildText;
+    } else if (channelData.type == ChannelType.GuildVoice) {
+        createOptions.bitrate = channelData.bitrate;
         createOptions.userLimit = channelData.userLimit;
         createOptions.type = channelData.type;
-    }
-
-    else if (channelData.type == ChannelType.GuildStageVoice) {
-        let bitrate = channelData.bitrate;
-        const bitrates = Object.values(MAX_BITRATE_PER_TIER);
-
-        while (bitrate > MAX_BITRATE_PER_TIER[guild.premiumTier]) {
-            bitrate = bitrates[guild.premiumTier];
-        }
-
+    } else if (channelData.type == ChannelType.GuildStageVoice) {
         createOptions.topic = channelData.topic;
         createOptions.nsfw = channelData.nsfw;
-        createOptions.rateLimitPerUser = channelData.rateLimitPerUser;
-        createOptions.bitrate = bitrate;
+        createOptions.bitrate = channelData.bitrate;
         createOptions.userLimit = channelData.userLimit;
-        createOptions.type = channelData.type;
-
-        /* Stage channels require the server to have Community features. */
-        if (!guild.features.includes(GuildFeature.Community)) return null;
+        createOptions.type = ChannelType.GuildStageVoice;
     }
 
-    const channel = await limiter.schedule({ id: `loadChannel::guild.channels.create::${channelData.name}` }, () => guild.channels.create(createOptions));
-    const finalPermissions = [];
+    const channel = await limiter.schedule(
+        { id: `loadChannel::guild.channels.create::${channelData.name}` },
+        () => guild.channels.create(createOptions)
+    );
 
-    channelData.permissions.forEach((permission) => {
-        const role = guild.roles.cache.find((role) => role.name == permission.roleName);
+    // Set channel permissions
+    const finalPermissions = [];
+    channelData.permissions.forEach(permission => {
+        const role = guild.roles.cache.find(role => role.name == permission.roleName);
         if (role) {
             finalPermissions.push({
                 id: role.id,
@@ -322,9 +343,12 @@ export async function loadChannel(channelData, guild, category, options, limiter
             });
         }
     });
+    await limiter.schedule(
+        { id: `loadChannel::channel.permissionOverwrites.set::${channel.name}` },
+        () => channel.permissionOverwrites.set(finalPermissions)
+    );
 
-    await limiter.schedule({ id: `loadChannel::channel.permissionOverwrites.set::${channel.name}` }, () => channel.permissionOverwrites.set(finalPermissions));
-
+    // Restore messages and threads in text channels
     if (channelData.type == ChannelType.GuildText) {
         let webhook;
 
@@ -333,16 +357,19 @@ export async function loadChannel(channelData, guild, category, options, limiter
         }
 
         if (channelData.threads.length > 0) {
-            channelData.threads.forEach(async (threadData, index) => {
-                const thread = await limiter.schedule({ id: `loadChannel::channel.threads.create::${index}.${threadData.name}` }, () => channel.threads.create({ name: threadData.name, autoArchiveDuration: threadData.autoArchiveDuration }));
-                if (webhook) await loadMessages(thread, threadData.messages, webhook);
-            });
-        }
-    }
+            for (let threadData of channelData.threads) {
+                if (restoredThreads.has(threadData.id)) continue; // Prevent restoring the thread multiple times
 
-    else if (channelData.type == ChannelType.GuildStageVoice) {
-        if (channelData.messages.length > 0) {
-            await loadMessages(channel, channelData.messages);
+                const thread = await limiter.schedule(
+                    { id: `loadChannel::channel.threads.create::${threadData.name}` },
+                    () => channel.threads.create({
+                        name: threadData.name,
+                        autoArchiveDuration: threadData.autoArchiveDuration
+                    })
+                );
+
+                if (webhook) await loadMessages(thread, threadData.messages, webhook);
+            }
         }
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -63,6 +63,7 @@ export function fetchVoiceChannelData(channel) {
         bitrate: channel.bitrate,
         userLimit: channel.userLimit,
         parent: channel.parent ? channel.parent.name : null,
+        parent_id: channel.parentId || null,
         permissions: fetchChannelPermissions(channel)
     };
 }
@@ -78,6 +79,7 @@ export async function fetchStageChannelData(channel, options, limiter) {
         bitrate: channel.bitrate,
         userLimit: channel.userLimit,
         parent: channel.parent ? channel.parent.name : null,
+        parent_id: channel.parentId || null,
         permissions: fetchChannelPermissions(channel),
         messages: []
     };
@@ -156,6 +158,7 @@ export async function fetchTextChannelData(channel, options, limiter) {
         nsfw: channel.nsfw,
         rateLimitPerUser: channel.type == ChannelType.GuildText ? channel.rateLimitPerUser : undefined,
         parent: channel.parent ? channel.parent.name : null,
+        parent_id: channel.parentId || null,
         topic: channel.topic,
         permissions: fetchChannelPermissions(channel),
         messages: [],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,7 @@ export declare interface CreateOptions {
     jsonSave?: boolean;
     jsonBeautify?: boolean;
     doNotBackup?: (string | { channels: string[] })[];
+    toBackup?: (string | { channels: string[] })[];
     backupMembers?: boolean;
     saveImages?: boolean | string;
     speed?: number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,6 +26,7 @@ export declare interface CreateOptions {
     backupMembers?: boolean;
     saveImages?: boolean | string;
     speed?: number;
+    concurrency?: number;
     verbose?: boolean;
     ignore2FA?: boolean;
     onStatusChange?: (status: BackupStatus) => void;
@@ -35,6 +36,7 @@ export declare interface LoadOptions {
     clearGuildBeforeRestore?: boolean;
     maxMessagesPerChannel?: number;
     speed?: number;
+    concurrency?: number;
     verbose?: boolean;
     doNotLoad?: string[];
     onStatusChange?: (status: BackupStatus) => void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,7 +39,8 @@ export declare interface LoadOptions {
     speed?: number;
     concurrency?: number;
     verbose?: boolean;
-    doNotLoad?: string[];
+    doNotLoad?: (string | { channels: string[] })[];
+    toLoad?: (string | { channels: string[] })[];
     onStatusChange?: (status: BackupStatus) => void;
 }
 


### PR DESCRIPTION
This PR introduces significant improvements to the backup process by adding the `toBackup` and `toLoad` options. These changes provide more granular control over channel inclusion and exclusion during backup and restoration.

- Added `toBackup` and `toLoad` options to specify channels for inclusion in the backup and restoration process.
- Updated logic to enforce mutual exclusivity between `toBackup` and `doNotBackup`.
- Updated documentation to reflect the new options and their usage.

These updates improve flexibility, maintainability, and clarity in the backup process.

This PR also contains git commits for bug fixes.